### PR TITLE
Fix ManuallyAssign when using a stage

### DIFF
--- a/functions/groups.js
+++ b/functions/groups.js
@@ -795,7 +795,7 @@ const ManuallyAssign = {
           var roomExt = extension.getExtension(room, 'Room')
           if (roomExt !== null) {
             var stage = (roomExt.stages || []).find((stage) => stage.id == ext.stageId)
-            if (stage.name == roomOrStage) {
+            if (stage.name == roomOrStage && group.activityCode.groupNumber === number) {
               return true
             }
           }


### PR DESCRIPTION
When a stage is specified instead of a room in ManuallyAssign, it didn't filter by group number, returning every group in the given round and stage. This PR fixes it.