### PR TITLE
Some fixes regarding OtherActivities

### DIFF
--- a/activity_code.js
+++ b/activity_code.js
@@ -94,7 +94,7 @@ class OtherActivity {
 function parse(code) {
   var codeSplit = code.split('-')
   if (codeSplit[0] == 'other') {
-    return new OtherActivity(codeSplit[1])
+    return new OtherActivity(codeSplit.slice(1).join('-'))
   }
   var eventId = codeSplit[0]
   if (!events.idToName[eventId]) {

--- a/lib.js
+++ b/lib.js
@@ -40,7 +40,7 @@ function allActivitiesForRoundId(competition, roundId) {
     .map((room) => room.activities
                        .map((activity) => activity.childActivities).flat()
                        .map((activity) => new groupLib.Group(activity, room, competition))).flat()
-    .filter(activity => activity.activityCode.group(null).id() === roundId)
+    .filter(activity => activity.activityCode.isActivity() && activity.activityCode.group(null).id() === roundId)
 }
 
 function allGroups(competition) {


### PR DESCRIPTION
`other-` activities may have childActivities, so we need to filter them in `allActivitiesForRoundId` function. Also, if you have, for example, `other-unofficial-magic-r1-g3`, the `parse` function was only returning `new OtherActivity('unofficial')`.